### PR TITLE
Set the DPL of the Idt entry for system call to user 

### DIFF
--- a/i386/mmu.h
+++ b/i386/mmu.h
@@ -106,13 +106,25 @@ typedef uint32_t PTE;
 
 // Each define here is for a specific flag in the descriptor.
 // Refer to the intel documentation for a description of what each one does.
+//
+//  31                23                15        11      7               0
+//  +-----------------+-+-+-+-+---------+-+-----+-+-----+-+-----------------+
+//  |                 | |D| |A|         | |     | |     | |                 |
+//  |   BASE 31..24   |G|B|L|V| LIMIT   |P| DPL |S| TYPE|A|  BASE 23..16    | 4
+//  |                 | | | |L| 19..16  | |     | |     | |                 |
+//  |-----------------+-+-+-+-+---------+-+-----+-+-----+-+-----------------|
+//  |                                   |                                   |
+//  |        SEGMENT BASE 15..0         |       SEGMENT LIMIT 15..0         | 0
+//  |                                   |                                   |
+//  +-----------------+-----------------+-----------------+-----------------+
+//                           0
 #define SEG_S(x)         ((x) << 0x04) // Descriptor type (0 for system, 1 for code/data)
+#define SEG_DPL(x)       (((x) & 0x03) << 0x05) // Set privilege level (0 - 3)
 #define SEG_P(x)         ((x) << 0x07) // Present
 #define SEG_AVL(x)       ((x) << 0x0c) // Available for system use
 #define SEG_L(x)         ((x) << 0x0d) // Long mode
 #define SEG_DB(x)        ((x) << 0x0e) // Size (0 for 16-bit, 1 for 32)
 #define SEG_G(x)         ((x) << 0x0f) // Granularity (0 for 1B - 1MB, 1 for 4KB - 4GB)
-#define SEG_DPL(x)       (((x) &  0x03) << 0x05) // Set privilege level (0 - 3)
  
 #define DPL_K              0x00
 #define DPL_U              0x03
@@ -141,43 +153,32 @@ typedef uint32_t PTE;
 
 /*! Task state segment */
 typedef struct TaskState {
-    uint16_t link;
-    uint16_t _padding0;
-    uint32_t esp0;
-    uint16_t ss0;
-    uint16_t _padding1;
-    uint32_t esp1;
-    uint16_t ss1;
-    uint16_t _padding2;
-    uint32_t esp2;
-    uint16_t ss2;
-    uint16_t _padding3;
-    uint32_t cr3;
-    uint32_t eip;
-    uint32_t eflags;
-    uint32_t eax;
-    uint32_t ecx;
-    uint32_t edx;
-    uint32_t ebx;
-    uint32_t esp;
-    uint32_t ebp;
-    uint32_t esi;
-    uint32_t edi;
-    uint16_t es;
-    uint16_t _padding4;
-    uint16_t cs;
-    uint16_t _padding5;
-    uint16_t ss;
-    uint16_t _padding6;
-    uint16_t ds;
-    uint16_t _padding7;
-    uint16_t fs;
-    uint16_t _padding8;
-    uint16_t gs;
-    uint16_t _padding9;
-    uint16_t ldtr;
-    uint16_t _padding10;
-    uint16_t t;
-    uint16_t iobp;
-    uint32_t ssp;
-} TaskState;
+	uint32_t link; // previous tss for hardware task switching
+	uint32_t esp0; // ring 0 esp
+	uint32_t ss0;  // ring 0 ss
+    // from these point is unused.
+	uint32_t esp1;
+	uint32_t ss1;
+	uint32_t esp2;
+	uint32_t ss2;
+	uint32_t cr3;
+	uint32_t eip;
+	uint32_t eflags;
+	uint32_t eax;
+	uint32_t ecx;
+	uint32_t edx;
+	uint32_t ebx;
+	uint32_t esp;
+	uint32_t ebp;
+	uint32_t esi;
+	uint32_t edi;
+	uint32_t es;
+	uint32_t cs;
+	uint32_t ss;
+	uint32_t ds;
+	uint32_t fs;
+	uint32_t gs;
+	uint32_t ldt;
+	uint16_t trap;
+	uint16_t iobp;
+} __attribute__((packed)) TaskState;

--- a/kernel/idt.h
+++ b/kernel/idt.h
@@ -20,14 +20,19 @@ typedef struct IDTRecord {
 } __attribute__((packed)) IDTRecord;
 
 
+/* idt flags */
 // 8 bytes flag that describes the idt
 // | 7 | 6-5 | 4 |  3-0      |
 // | p | dpl | 0 | gate type |
-enum IDTFlags {
-    InterruptGate = 0x8E,   // handle interrupt
-    TrapGate = 0x8F,        // handle trap
-    TaskGate = 0x85         // for hardware task switching
-};
+
+#define GATE_DPL(x)       (((x) & 0x03) << 0x05) // Set privilege level (0 - 3)
+#define GATE_P(x)         ((x) << 0x07) // Present
+
+/* Gate types */
+#define TASK_GATE         0x5
+#define INT_GATE          0xe
+#define TRAP_GATE         0xf
+
 
 
 void *get_handler_from_idt(uint8_t vector);

--- a/kernel/process/init1.s
+++ b/kernel/process/init1.s
@@ -1,7 +1,12 @@
+#include "traps.h"
+#include "sys/syscalls.h"
+
 section .init1
 
 global init1
 init1:
+    mov eax, SYS_GETPID
+    int I_SYSCALL
 loop: jmp loop
 
 msg:

--- a/kernel/process/proc.c
+++ b/kernel/process/proc.c
@@ -185,8 +185,8 @@ static Process *allocate_process() {
 
 
 /*! Setup the trapframe for the first process to create an illusion
- * that a trap occured. So if we call trapret, it will pop all registers
- * in the trap frame hence switch the control.
+ *  that a trap occured. So if we call trapret, it will pop all registers
+ *  in the trap frame hence switch the control.
  * */
 static void set_pid1_trapframe(Process *p) {
     memset(p->trapframe, 0, sizeof(*p->trapframe));

--- a/kernel/sys/syscall.c
+++ b/kernel/sys/syscall.c
@@ -1,3 +1,4 @@
+#include "err.h"
 #include "sys/syscall.h"
 #include "sys/syscalls.h"
 #include "process/proc.h"
@@ -34,7 +35,27 @@ static int (* system_calls[])() = {
 };
 
 
-/* Invoke system call from trap frame */
+static bool is_valid_syscall(int n) {
+    return (n > 0 && n < sizeof(system_calls) / sizeof(system_calls[0]) && system_calls[n]);
+}
+
+
+/* Invoke system call from trap frame. The system call needs to parse their
+ * own arguments.
+ * */
 void syscall() {
     Process *p = this_proc();
+    if (p == 0) {
+        panic("syscall: invalid process");
+    }
+
+    int n = p->trapframe->eax;
+    if (!is_valid_syscall(n)) {
+        p->trapframe->eax = -1;
+        perror("known system call");
+        return;
+    }
+
+    int r = system_calls[n]();
+    p->trapframe->eax = r;
 }

--- a/kernel/sys/syscall.c
+++ b/kernel/sys/syscall.c
@@ -4,6 +4,7 @@
 #include "process/proc.h"
 
 
+
 int sys_fork() {
     return fork();
 }

--- a/kernel/sys/syscalls.h
+++ b/kernel/sys/syscalls.h
@@ -2,6 +2,6 @@
 
 #define SYS_FORK    1
 #define SYS_EXIT    2
-#define SYS_EXEC    4 
-#define SYS_GETPID  5
-#define SYS_SBRK    6
+#define SYS_EXEC    3
+#define SYS_GETPID  4
+#define SYS_SBRK    5

--- a/kernel/trap.c
+++ b/kernel/trap.c
@@ -129,6 +129,8 @@ void handle_I_IRQ_SPURIOUS(const TrapFrame *tf) {
 void trap(TrapFrame *tf) {
     switch (tf->trapno) {
         case I_SYSCALL:
+            handle_syscall(tf);
+            break;
         case MAP_IRQ(I_IRQ_TIMER):
             handle_I_IRQ_TIMER();
             break;

--- a/kernel/trap.c
+++ b/kernel/trap.c
@@ -1,6 +1,7 @@
 #include "trap.h"
 #include "debug.h"
 #include "err.h"
+#include "mmu.h"
 #include "traps.h"
 #include "tty.h"
 #include "idt.h"
@@ -42,9 +43,15 @@ static void dump_trapframe(const TrapFrame *tf) {
 
 void trap_init() {
     for (int i = 0; i < 256; ++i) {
-        regist_idt_handler(i, vectors[i], InterruptGate);
+        regist_idt_handler(
+                i,
+                vectors[i],
+                GATE_P(1) | GATE_DPL(DPL_K) | INT_GATE);
     }
-    regist_idt_handler(I_SYSCALL, vectors[I_SYSCALL], TrapGate);
+    regist_idt_handler(
+            I_SYSCALL,
+            vectors[I_SYSCALL],
+            GATE_P(1) | GATE_DPL(DPL_U) | TRAP_GATE);
 }
 
 /*! When a system call is invoked, the system call number is


### PR DESCRIPTION
The first user space process `init1.s` could not return to kernel space because the IDT descriptor for the system call vector has DPL 0, but the system call interrupt is performed in the user space with DPL 3. We add more macros to create IDT descriptor flags with finer granularity and use the new macros to set the system call DPL to 3. This allows us to return to kernel space successfully.